### PR TITLE
fix(state): accept alternate device state response shapes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.1.13",
+      "version": "3.1.14",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/infrastructure/response-schemas.ts
+++ b/src/infrastructure/response-schemas.ts
@@ -47,16 +47,55 @@ export const GoveeStateCapabilitySchema = z.object({
   }),
 });
 
-// Device state API response schema
-export const GoveeStateResponseSchema = z.object({
-  code: z.number(),
-  message: z.string(),
-  data: z.object({
-    device: z.string().min(1, 'Device ID must be a non-empty string'),
-    sku: z.string().min(1, 'SKU must be a non-empty string'),
-    capabilities: z.array(GoveeStateCapabilitySchema),
-  }),
+const GoveeStatePayloadSchema = z.object({
+  device: z.string().min(1, 'Device ID must be a non-empty string'),
+  sku: z.string().min(1, 'SKU must be a non-empty string'),
+  capabilities: z.array(GoveeStateCapabilitySchema),
 });
+
+// Device state API response schema
+export const GoveeStateResponseSchema = z
+  .object({
+    code: z.number(),
+    message: z.string().optional(),
+    msg: z.string().optional(),
+    data: z.unknown().optional(),
+    payload: z.unknown().optional(),
+  })
+  .transform((response, ctx) => {
+    const message = response.message ?? response.msg;
+
+    if (typeof message !== 'string') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'State response must include either a message or msg field',
+        path: ['message'],
+      });
+    }
+
+    const payload = response.data ?? response.payload;
+    const parsedPayload = GoveeStatePayloadSchema.safeParse(payload);
+
+    if (!parsedPayload.success) {
+      for (const issue of parsedPayload.error.issues) {
+        ctx.addIssue({
+          ...issue,
+          path: ['data', ...issue.path],
+        });
+      }
+      return z.NEVER;
+    }
+
+    if (typeof message !== 'string') {
+      return z.NEVER;
+    }
+
+    return {
+      ...response,
+      message,
+      data: parsedPayload.data,
+    };
+  });
 
 // Command API response schema
 export const GoveeCommandResponseSchema = z

--- a/tests/integration/GoveeClient.test.ts
+++ b/tests/integration/GoveeClient.test.ts
@@ -229,6 +229,29 @@ describe('GoveeClient Integration Tests', () => {
       expect(state.getBrightness()?.level).toBe(75);
     });
 
+    it('should get device state when the API returns msg and payload', async () => {
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () => {
+          return HttpResponse.json({
+            code: 200,
+            msg: 'success',
+            payload: {
+              ...mockStateResponse.data,
+              sku: 'H6056',
+            },
+          });
+        })
+      );
+
+      const state = await client.getDeviceState('living-room-123', 'H6056');
+
+      expect(state.deviceId).toBe('living-room-123');
+      expect(state.model).toBe('H6056');
+      expect(state.online).toBe(true);
+      expect(state.getPowerState()).toBe('on');
+      expect(state.getBrightness()?.level).toBe(75);
+    });
+
     it('should check if device is online', async () => {
       const isOnline = await client.isDeviceOnline('living-room-123', 'H6159');
 

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -217,6 +217,25 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(state.getColorTemperature()?.kelvin).toBe(2700);
     });
 
+    it('should accept state responses that use msg and payload', async () => {
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () => {
+          return HttpResponse.json({
+            code: 200,
+            msg: 'success',
+            payload: mockStateResponse.data,
+          });
+        })
+      );
+
+      const state = await repository.findState('device123', 'H6056');
+
+      expect(state.deviceId).toBe('device123');
+      expect(state.model).toBe('H6056');
+      expect(state.getPowerState()).toBe('on');
+      expect(state.getBrightness()?.level).toBe(75);
+    });
+
     it('should handle device offline state', async () => {
       const offlineStateResponse = {
         ...mockStateResponse,


### PR DESCRIPTION
## Summary
- accept device-state responses that return `msg` instead of `message`
- accept device-state responses that return `payload` instead of `data`
- add regression coverage for both repository and public client `getDeviceState()` paths

## Why
Some devices, including `H6056`, appear to return an alternate top-level response shape from the device-state endpoint. Command calls succeed, but `getDeviceState()` fails Zod validation with:

```txt
Invalid input at path 'message', Invalid input at path 'data'
```

This breaks live toggle logic, post-command verification, and UI state sync.

## Changes
- updated `GoveeStateResponseSchema` to normalize:
  - `message ?? msg`
  - `data ?? payload`
- kept payload validation strict after normalization
- added integration tests covering the alternate response shape

## Testing
- `npx vitest run tests/integration/GoveeDeviceRepository.test.ts`
- `npx vitest run tests/integration/GoveeClient.test.ts`

## Release
- bumped package version to `3.1.14`