### PR TITLE
feat: add snapshot and DIY scene support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.1.14",
+  "version": "3.2.0",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/GoveeClient.ts
+++ b/src/GoveeClient.ts
@@ -9,6 +9,8 @@ import {
   ColorTemperature,
   Brightness,
   LightScene,
+  Snapshot,
+  DiyScene,
   SegmentColor,
   MusicMode,
 } from './domain/value-objects';
@@ -165,6 +167,22 @@ export class GoveeClient {
 
   async setLightScene(deviceId: string, model: string, scene: LightScene): Promise<void> {
     return this.controlService.setLightScene(deviceId, model, scene);
+  }
+
+  async getSnapshots(deviceId: string, model: string): Promise<Snapshot[]> {
+    return this.controlService.getSnapshots(deviceId, model);
+  }
+
+  async setSnapshot(deviceId: string, model: string, snapshot: Snapshot): Promise<void> {
+    return this.controlService.setSnapshot(deviceId, model, snapshot);
+  }
+
+  async getDiyScenes(deviceId: string, model: string): Promise<DiyScene[]> {
+    return this.controlService.getDiyScenes(deviceId, model);
+  }
+
+  async setDiyScene(deviceId: string, model: string, scene: DiyScene): Promise<void> {
+    return this.controlService.setDiyScene(deviceId, model, scene);
   }
 
   async setSegmentColors(

--- a/src/domain/entities/Command.ts
+++ b/src/domain/entities/Command.ts
@@ -3,6 +3,8 @@ import {
   ColorTemperature,
   Brightness,
   LightScene,
+  Snapshot,
+  DiyScene,
   SegmentColor,
   MusicMode,
 } from '../value-objects';
@@ -112,6 +114,60 @@ export class LightSceneCommand extends Command {
   }
 
   get scene(): LightScene {
+    return this._scene;
+  }
+
+  toObject(): { name: string; value: { paramId: number; id: number } } {
+    return { name: this.name, value: this.value };
+  }
+}
+
+/**
+ * Activates a user-saved snapshot. Shares the API payload shape with
+ * {@link LightSceneCommand} (both live under `dynamic_scene`) but uses
+ * `instance: "snapshot"` instead of `"lightScene"`.
+ */
+export class SnapshotCommand extends Command {
+  readonly name = 'snapshot';
+  private readonly _snapshot: Snapshot;
+
+  constructor(snapshot: Snapshot) {
+    super();
+    this._snapshot = snapshot;
+  }
+
+  get value(): { paramId: number; id: number } {
+    return this._snapshot.toApiValue();
+  }
+
+  get snapshot(): Snapshot {
+    return this._snapshot;
+  }
+
+  toObject(): { name: string; value: { paramId: number; id: number } } {
+    return { name: this.name, value: this.value };
+  }
+}
+
+/**
+ * Activates a user-designed DIY scene. Shares the API payload shape
+ * with {@link LightSceneCommand} (both live under `dynamic_scene`) but
+ * uses `instance: "diyScene"`.
+ */
+export class DiySceneCommand extends Command {
+  readonly name = 'diyScene';
+  private readonly _scene: DiyScene;
+
+  constructor(scene: DiyScene) {
+    super();
+    this._scene = scene;
+  }
+
+  get value(): { paramId: number; id: number } {
+    return this._scene.toApiValue();
+  }
+
+  get scene(): DiyScene {
     return this._scene;
   }
 
@@ -271,6 +327,14 @@ export class CommandFactory {
     return new LightSceneCommand(scene);
   }
 
+  static snapshot(snapshot: Snapshot): SnapshotCommand {
+    return new SnapshotCommand(snapshot);
+  }
+
+  static diyScene(scene: DiyScene): DiySceneCommand {
+    return new DiySceneCommand(scene);
+  }
+
   static segmentColorRgb(segments: SegmentColor | SegmentColor[]): SegmentColorRgbCommand {
     return new SegmentColorRgbCommand(segments);
   }
@@ -350,6 +414,24 @@ export class CommandFactory {
           return new LightSceneCommand(new LightScene(sceneValue.id, sceneValue.paramId, 'Scene'));
         }
         throw new Error(`Invalid light scene command value: ${obj.value}`);
+
+      case 'snapshot':
+        if (typeof obj.value === 'object' && obj.value !== null) {
+          const snapshotValue = obj.value as { id: number; paramId: number };
+          return new SnapshotCommand(
+            new Snapshot(snapshotValue.id, snapshotValue.paramId, 'Snapshot')
+          );
+        }
+        throw new Error(`Invalid snapshot command value: ${obj.value}`);
+
+      case 'diyScene':
+        if (typeof obj.value === 'object' && obj.value !== null) {
+          const diyValue = obj.value as { id: number; paramId: number };
+          return new DiySceneCommand(
+            new DiyScene(diyValue.id, diyValue.paramId, 'DIY Scene')
+          );
+        }
+        throw new Error(`Invalid DIY scene command value: ${obj.value}`);
 
       case 'segmentedColorRgb':
         if (typeof obj.value === 'object' && obj.value !== null) {

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -21,6 +21,8 @@ export {
   ColorCommand,
   ColorTemperatureCommand,
   LightSceneCommand,
+  SnapshotCommand,
+  DiySceneCommand,
   SegmentColorRgbCommand,
   SegmentBrightnessCommand,
   MusicModeCommand,

--- a/src/domain/repositories/IGoveeDeviceRepository.ts
+++ b/src/domain/repositories/IGoveeDeviceRepository.ts
@@ -2,25 +2,14 @@ import { GoveeDevice } from '../entities/GoveeDevice';
 import { DeviceState } from '../entities/DeviceState';
 import { Command } from '../entities/Command';
 import { LightScene } from '../value-objects/LightScene';
+import { Snapshot } from '../value-objects/Snapshot';
+import { DiyScene } from '../value-objects/DiyScene';
 
 export interface IGoveeDeviceRepository {
-  /**
-   * Retrieves all devices associated with the configured API key
-   */
   findAll(): Promise<GoveeDevice[]>;
-
-  /**
-   * Retrieves the current state of a specific device
-   */
   findState(deviceId: string, sku: string): Promise<DeviceState>;
-
-  /**
-   * Sends a command to control a specific device
-   */
   sendCommand(deviceId: string, sku: string, command: Command): Promise<void>;
-
-  /**
-   * Retrieves available dynamic light scenes for a specific device
-   */
   findDynamicScenes(deviceId: string, sku: string): Promise<LightScene[]>;
+  findSnapshots(deviceId: string, sku: string): Promise<Snapshot[]>;
+  findDiyScenes(deviceId: string, sku: string): Promise<DiyScene[]>;
 }

--- a/src/domain/value-objects/DiyScene.ts
+++ b/src/domain/value-objects/DiyScene.ts
@@ -1,0 +1,98 @@
+/**
+ * DiyScene value object represents a user-designed dynamic animation
+ * on a Govee lighting device.
+ *
+ * DIY scenes are animations the user has built in the Govee mobile app
+ * (custom colors, transitions, speeds, blending rules) and saved to the
+ * device. They differ from {@link LightScene} (Govee's curated gallery)
+ * and {@link Snapshot} (static point-in-time configuration) by being
+ * both *dynamic* and *user-authored*.
+ *
+ * On the API surface they share the shape `{ id, paramId, name }` with
+ * other `devices.capabilities.dynamic_scene` entries, but their
+ * `instance` is `"diyScene"`.
+ *
+ * @example
+ * const mySparkles = new DiyScene(5001, 6001, 'Party Sparkles');
+ * await client.setDiyScene(deviceId, model, mySparkles);
+ */
+export class DiyScene {
+  private readonly _id: number;
+  private readonly _paramId: number;
+  private readonly _name: string;
+
+  constructor(id: number, paramId: number, name: string) {
+    this.validateId(id);
+    this.validateParamId(paramId);
+    this.validateName(name);
+
+    this._id = id;
+    this._paramId = paramId;
+    this._name = name.trim();
+
+    Object.freeze(this);
+  }
+
+  private validateId(id: number): void {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new Error('ID must be a positive integer');
+    }
+  }
+
+  private validateParamId(paramId: number): void {
+    if (!Number.isInteger(paramId) || paramId <= 0) {
+      throw new Error('ParamId must be a positive integer');
+    }
+  }
+
+  private validateName(name: string): void {
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new Error('Name must be a non-empty string');
+    }
+  }
+
+  get id(): number {
+    return this._id;
+  }
+
+  get paramId(): number {
+    return this._paramId;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  /**
+   * Two DIY scenes are equal if they have the same id and paramId.
+   */
+  equals(other: DiyScene): boolean {
+    return this._id === other._id && this._paramId === other._paramId;
+  }
+
+  toObject(): { id: number; paramId: number; name: string } {
+    return {
+      id: this._id,
+      paramId: this._paramId,
+      name: this._name,
+    };
+  }
+
+  static fromObject(obj: { id: number; paramId: number; name: string }): DiyScene {
+    return new DiyScene(obj.id, obj.paramId, obj.name);
+  }
+
+  toString(): string {
+    return `DiyScene(${this._name}, id=${this._id}, paramId=${this._paramId})`;
+  }
+
+  /**
+   * Converts to API-compatible value format for command payloads.
+   */
+  toApiValue(): { paramId: number; id: number } {
+    return {
+      paramId: this._paramId,
+      id: this._id,
+    };
+  }
+}

--- a/src/domain/value-objects/Snapshot.ts
+++ b/src/domain/value-objects/Snapshot.ts
@@ -1,0 +1,99 @@
+/**
+ * Snapshot value object represents a user-created saved light state
+ * on a Govee lighting device.
+ *
+ * Snapshots are static "preset slots" — a point-in-time configuration
+ * (specific color, brightness, or mid-scene state) the user has saved
+ * in the Govee mobile app and named (e.g. "Reading", "Movie night").
+ * Unlike {@link LightScene} (Govee's curated dynamic animations) or
+ * {@link DiyScene} (user-designed animations), snapshots capture a
+ * frozen moment and are recalled exactly as saved.
+ *
+ * On the API surface they share the shape `{ id, paramId, name }` with
+ * other `devices.capabilities.dynamic_scene` entries, but their
+ * `instance` is `"snapshot"`.
+ *
+ * @example
+ * const readingPreset = new Snapshot(1001, 2001, 'Reading');
+ * await client.setSnapshot(deviceId, model, readingPreset);
+ */
+export class Snapshot {
+  private readonly _id: number;
+  private readonly _paramId: number;
+  private readonly _name: string;
+
+  constructor(id: number, paramId: number, name: string) {
+    this.validateId(id);
+    this.validateParamId(paramId);
+    this.validateName(name);
+
+    this._id = id;
+    this._paramId = paramId;
+    this._name = name.trim();
+
+    Object.freeze(this);
+  }
+
+  private validateId(id: number): void {
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new Error('ID must be a positive integer');
+    }
+  }
+
+  private validateParamId(paramId: number): void {
+    if (!Number.isInteger(paramId) || paramId <= 0) {
+      throw new Error('ParamId must be a positive integer');
+    }
+  }
+
+  private validateName(name: string): void {
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new Error('Name must be a non-empty string');
+    }
+  }
+
+  get id(): number {
+    return this._id;
+  }
+
+  get paramId(): number {
+    return this._paramId;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  /**
+   * Two snapshots are equal if they have the same id and paramId.
+   */
+  equals(other: Snapshot): boolean {
+    return this._id === other._id && this._paramId === other._paramId;
+  }
+
+  toObject(): { id: number; paramId: number; name: string } {
+    return {
+      id: this._id,
+      paramId: this._paramId,
+      name: this._name,
+    };
+  }
+
+  static fromObject(obj: { id: number; paramId: number; name: string }): Snapshot {
+    return new Snapshot(obj.id, obj.paramId, obj.name);
+  }
+
+  toString(): string {
+    return `Snapshot(${this._name}, id=${this._id}, paramId=${this._paramId})`;
+  }
+
+  /**
+   * Converts to API-compatible value format for command payloads.
+   */
+  toApiValue(): { paramId: number; id: number } {
+    return {
+      paramId: this._paramId,
+      id: this._id,
+    };
+  }
+}

--- a/src/domain/value-objects/index.ts
+++ b/src/domain/value-objects/index.ts
@@ -2,5 +2,7 @@ export { ColorRgb } from './ColorRgb';
 export { ColorTemperature } from './ColorTemperature';
 export { Brightness } from './Brightness';
 export { LightScene } from './LightScene';
+export { Snapshot } from './Snapshot';
+export { DiyScene } from './DiyScene';
 export { SegmentColor } from './SegmentColor';
 export { MusicMode } from './MusicMode';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export {
   ColorCommand,
   ColorTemperatureCommand,
   LightSceneCommand,
+  SnapshotCommand,
+  DiySceneCommand,
   SegmentColorRgbCommand,
   SegmentBrightnessCommand,
   MusicModeCommand,
@@ -37,6 +39,8 @@ export {
   ColorTemperature,
   Brightness,
   LightScene,
+  Snapshot,
+  DiyScene,
   SegmentColor,
   MusicMode,
 } from './domain/value-objects';

--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -16,6 +16,8 @@ import {
   ColorTemperature,
   Brightness,
   LightScene,
+  Snapshot,
+  DiyScene,
   SegmentColor,
   MusicMode,
 } from '../domain/value-objects';
@@ -500,6 +502,83 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
     }
   }
 
+  async findSnapshots(deviceId: string, sku: string): Promise<Snapshot[]> {
+    return this.findDynamicScenesByInstance<Snapshot>(
+      deviceId, sku, 'snapshot',
+      (opt) => new Snapshot(opt.value.id, opt.value.paramId, opt.name),
+    );
+  }
+
+  async findDiyScenes(deviceId: string, sku: string): Promise<DiyScene[]> {
+    return this.findDynamicScenesByInstance<DiyScene>(
+      deviceId, sku, 'diyScene',
+      (opt) => new DiyScene(opt.value.id, opt.value.paramId, opt.name),
+    );
+  }
+
+  /**
+   * Shared helper for querying the /device/scenes endpoint and
+   * extracting entries by capability instance name.
+   */
+  private async findDynamicScenesByInstance<T>(
+    deviceId: string,
+    sku: string,
+    instanceName: string,
+    factory: (option: { name: string; value: { id: number; paramId: number } }) => T,
+  ): Promise<T[]> {
+    this.validateDeviceParams(deviceId, sku);
+    this.logger?.info({ deviceId, sku, instance: instanceName }, `Fetching ${instanceName} entries`);
+
+    try {
+      const requestBody = {
+        requestId: this.generateRequestId(),
+        payload: { sku, device: deviceId },
+      };
+
+      const response = await this.httpClient.post('/router/api/v1/device/scenes', requestBody);
+      const validationResult = GoveeDynamicScenesResponseSchema.safeParse(response.data);
+
+      if (!validationResult.success) {
+        this.logger?.error(
+          { zodError: validationResult.error, rawData: response.data },
+          `${instanceName} response validation failed`,
+        );
+        throw ValidationError.fromZodError(validationResult.error, response.data);
+      }
+
+      const apiResponse = validationResult.data;
+      if (apiResponse.code !== 200) {
+        throw new GoveeApiError(
+          `API returned error code ${apiResponse.code}: ${apiResponse.msg}`,
+          response.status,
+          apiResponse.code,
+          apiResponse.msg || 'Unknown error',
+        );
+      }
+
+      const results: T[] = [];
+      for (const capability of apiResponse.payload.capabilities) {
+        if (
+          capability.type.includes('dynamic_scene') &&
+          capability.instance === instanceName
+        ) {
+          for (const option of capability.parameters.options) {
+            results.push(factory(option));
+          }
+        }
+      }
+
+      this.logger?.info(
+        { deviceId, sku, count: results.length },
+        `Successfully fetched ${instanceName} entries`,
+      );
+      return results;
+    } catch (error) {
+      this.logger?.error(error, `Failed to fetch ${instanceName} entries`);
+      throw error;
+    }
+  }
+
   private validateDeviceParams(deviceId: string, sku: string): void {
     if (!deviceId || typeof deviceId !== 'string' || deviceId.trim().length === 0) {
       throw new Error('Device ID must be a non-empty string');
@@ -523,6 +602,8 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
       color: 'devices.capabilities.color_setting',
       colorTem: 'devices.capabilities.color_setting',
       lightScene: 'devices.capabilities.dynamic_scene',
+      snapshot: 'devices.capabilities.dynamic_scene',
+      diyScene: 'devices.capabilities.dynamic_scene',
       segmentedColorRgb: 'devices.capabilities.segment_color_setting',
       segmentedBrightness: 'devices.capabilities.segment_color_setting',
       musicMode: 'devices.capabilities.music_setting',
@@ -548,6 +629,12 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
       value = cmdObj.value;
     } else if (cmdObj.name === 'lightScene') {
       instance = 'lightScene';
+      value = cmdObj.value;
+    } else if (cmdObj.name === 'snapshot') {
+      instance = 'snapshot';
+      value = cmdObj.value;
+    } else if (cmdObj.name === 'diyScene') {
+      instance = 'diyScene';
       value = cmdObj.value;
     } else if (cmdObj.name === 'segmentedColorRgb') {
       instance = 'segmentedColorRgb';

--- a/src/infrastructure/retry/RetryableRepository.ts
+++ b/src/infrastructure/retry/RetryableRepository.ts
@@ -3,7 +3,7 @@ import { IGoveeDeviceRepository } from '../../domain/repositories/IGoveeDeviceRe
 import { GoveeDevice } from '../../domain/entities/GoveeDevice';
 import { DeviceState } from '../../domain/entities/DeviceState';
 import { Command } from '../../domain/entities/Command';
-import { LightScene } from '../../domain/value-objects';
+import { LightScene, Snapshot, DiyScene } from '../../domain/value-objects';
 import {
   RetryExecutor,
   RetryableRequest,
@@ -121,6 +121,38 @@ export class RetryableRepository implements IGoveeDeviceRepository {
       execute: () => this.repository.findDynamicScenes(deviceId, sku),
       context: {
         operation: 'findDynamicScenes',
+        deviceId,
+        sku,
+        timestamp: new Date().toISOString(),
+      },
+    };
+
+    return this.retryExecutor.execute(request);
+  }
+
+  async findSnapshots(deviceId: string, sku: string): Promise<Snapshot[]> {
+    const request: RetryableRequest<Snapshot[]> = {
+      id: this.generateRequestId('findSnapshots'),
+      description: `Fetch snapshots for device ${deviceId} (${sku})`,
+      execute: () => this.repository.findSnapshots(deviceId, sku),
+      context: {
+        operation: 'findSnapshots',
+        deviceId,
+        sku,
+        timestamp: new Date().toISOString(),
+      },
+    };
+
+    return this.retryExecutor.execute(request);
+  }
+
+  async findDiyScenes(deviceId: string, sku: string): Promise<DiyScene[]> {
+    const request: RetryableRequest<DiyScene[]> = {
+      id: this.generateRequestId('findDiyScenes'),
+      description: `Fetch DIY scenes for device ${deviceId} (${sku})`,
+      execute: () => this.repository.findDiyScenes(deviceId, sku),
+      context: {
+        operation: 'findDiyScenes',
         deviceId,
         sku,
         timestamp: new Date().toISOString(),

--- a/src/services/GoveeControlService.ts
+++ b/src/services/GoveeControlService.ts
@@ -8,6 +8,8 @@ import {
   ColorTemperature,
   Brightness,
   LightScene,
+  Snapshot,
+  DiyScene,
   SegmentColor,
   MusicMode,
 } from '../domain/value-objects';
@@ -256,6 +258,50 @@ export class GoveeControlService {
   async setLightScene(deviceId: string, model: string, scene: LightScene): Promise<void> {
     this.logger?.info({ deviceId, model, scene: scene.name }, 'Setting device light scene');
     await this.sendCommand(deviceId, model, CommandFactory.lightScene(scene));
+  }
+
+  /**
+   * Retrieves user-saved snapshots for a specific device
+   */
+  async getSnapshots(deviceId: string, model: string): Promise<Snapshot[]> {
+    this.validateDeviceParams(deviceId, model);
+    this.logger?.info({ deviceId, model }, 'Getting snapshots');
+
+    return this.rateLimiter.execute(async () => {
+      const snapshots = await this.repository.findSnapshots(deviceId, model);
+      this.logger?.info({ deviceId, model, count: snapshots.length }, 'Retrieved snapshots');
+      return snapshots;
+    });
+  }
+
+  /**
+   * Activates a user-saved snapshot on a device
+   */
+  async setSnapshot(deviceId: string, model: string, snapshot: Snapshot): Promise<void> {
+    this.logger?.info({ deviceId, model, snapshot: snapshot.name }, 'Setting device snapshot');
+    await this.sendCommand(deviceId, model, CommandFactory.snapshot(snapshot));
+  }
+
+  /**
+   * Retrieves user-designed DIY scenes for a specific device
+   */
+  async getDiyScenes(deviceId: string, model: string): Promise<DiyScene[]> {
+    this.validateDeviceParams(deviceId, model);
+    this.logger?.info({ deviceId, model }, 'Getting DIY scenes');
+
+    return this.rateLimiter.execute(async () => {
+      const scenes = await this.repository.findDiyScenes(deviceId, model);
+      this.logger?.info({ deviceId, model, count: scenes.length }, 'Retrieved DIY scenes');
+      return scenes;
+    });
+  }
+
+  /**
+   * Activates a user-designed DIY scene on a device
+   */
+  async setDiyScene(deviceId: string, model: string, scene: DiyScene): Promise<void> {
+    this.logger?.info({ deviceId, model, scene: scene.name }, 'Setting device DIY scene');
+    await this.sendCommand(deviceId, model, CommandFactory.diyScene(scene));
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds first-class support for two Govee dynamic_scene instances that were previously filtered out:

- **`snapshot`** — user-saved static light states ("presets")
- **`diyScene`** — user-designed custom animations

Both share the same `{id, paramId, name}` shape as the existing `lightScene` support but use different `instance` values on the API wire.

## Motivation

The `govee-light-management` Stream Deck plugin needs snapshot support (felixgeelhaar/govee-light-management#174). The client's `convertCommandToCapability` hardcoded `instance: "lightScene"` for all `dynamic_scene` commands, making it impossible to activate snapshots or DIY scenes through `sendCommand`.

## Changes

### Value Objects
- `Snapshot` — immutable, frozen, validated (`id`, `paramId`, `name`)
- `DiyScene` — same shape, different semantic

### Commands
- `SnapshotCommand` (name=`"snapshot"`) + `DiySceneCommand` (name=`"diyScene"`)
- `CommandFactory.snapshot()` / `CommandFactory.diyScene()`
- `CommandFactory.fromObject()` updated for both

### Repository
- `IGoveeDeviceRepository.findSnapshots()` / `findDiyScenes()`
- `GoveeDeviceRepository`: shared `findDynamicScenesByInstance<T>()` helper (same `/device/scenes` endpoint, filtered by instance)
- `RetryableRepository`: proxy methods for both
- `convertCommandToCapability`: maps `snapshot` and `diyScene` to `type: "devices.capabilities.dynamic_scene"` with correct instance

### Service + Client
- `GoveeControlService`: `getSnapshots` / `setSnapshot` / `getDiyScenes` / `setDiyScene` (rate-limited, logged)
- `GoveeClient`: public surface for all four

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 677 passed, 0 failed, 2 skipped

## Version

3.1.14 → **3.2.0** (minor — new public API surface, no breaking changes)