### PR TITLE
feat: parse online capability + release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-04-18
+
+### Fixed
+
+- **DIY scenes on dedicated endpoint**: `findDiyScenes` now POSTs to `/router/api/v1/device/diy-scenes` (the dedicated Govee endpoint) instead of the general `/device/scenes` endpoint. DIY scenes were silently returning empty for all but the narrowest set of devices because the general endpoint does not enumerate DIY scenes.
+- **DIY command payload shape**: `DiySceneCommand.value` is now the numeric DIY scene ID expected by Govee control, not the previous `{ id, paramId }` object. Existing object-shape commands are still accepted for deserialization.
+- **Mixed scene value tolerance**: Dynamic scene parsing now tolerates a mix of structured `{ id, paramId }` values and bare numeric IDs within the same response. A single malformed option no longer invalidates the full payload — each unparseable option is skipped with a debug log.
+- **Online state parsing**: `findState` now reads the actual `devices.capabilities.online` capability value (boolean, numeric, or string form) and populates `DeviceState.online` accordingly. Previously hardcoded to `true` whenever a response was received, which masked real offline state on devices that report it. Defaults to `true` when the capability is absent to preserve backward compatibility.
+
+### Added
+
+- **Snapshot fallback from capability metadata**: `findSnapshots` now falls back to enumerating snapshots from `/user/devices` capability metadata when `/device/scenes` returns no snapshot entries. Fixes capability-driven devices like H61E5 where snapshot options are exposed through the device list rather than the scenes endpoint.
+- **DIY `diy_color_setting` capability type**: DIY scene discovery now recognizes the `devices.capabilities.diy_color_setting` capability type in addition to `devices.capabilities.dynamic_scene`.
+- **Nested parameter preservation**: Capability parameter schemas now preserve `fields` and `range` via `.passthrough()`, matching the richer responses returned by `/user/devices`.
+
+### Tests
+
+- 11 new integration tests covering the DIY endpoint path, numeric vs structured value shapes, mixed-shape tolerance, snapshot fallback, and online state parsing across boolean/numeric/string value variants.
+
 ## [3.1.13] - 2026-04-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.1.14",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.1.14",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -384,12 +384,12 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
       // Parse capabilities into state properties
       const stateProperties = this.mapCapabilitiesToStateProperties(apiResponse.data.capabilities);
 
-      const deviceState = new DeviceState(
-        deviceId,
-        sku,
-        true, // Assume online if we get a response
-        stateProperties
-      );
+      // Parse the device's actual online state from the online capability.
+      // Defaults to true when absent, matching pre-existing behavior — some
+      // devices don't report online state explicitly but clearly respond.
+      const online = this.parseOnlineState(apiResponse.data.capabilities);
+
+      const deviceState = new DeviceState(deviceId, sku, online, stateProperties);
 
       this.logger?.info({ deviceId, sku }, 'Successfully fetched device state');
       return deviceState;
@@ -871,6 +871,30 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
     }
 
     return value as { r: number; g: number; b: number };
+  }
+
+  /**
+   * Read the device's actual online state from the `devices.capabilities.online`
+   * capability if present. Returns true when the capability is missing so we
+   * don't regress behavior for devices that don't report online state yet
+   * still respond to the state endpoint.
+   */
+  private parseOnlineState(
+    capabilities: Array<{ type: string; instance: string; state: { value: unknown } }>
+  ): boolean {
+    for (const capability of capabilities) {
+      if (capability.type.includes('online')) {
+        const value = capability.state.value;
+        if (typeof value === 'boolean') return value;
+        if (typeof value === 'number') return value !== 0;
+        if (typeof value === 'string') {
+          const lowered = value.toLowerCase();
+          if (lowered === 'true' || lowered === 'online' || lowered === '1') return true;
+          if (lowered === 'false' || lowered === 'offline' || lowered === '0') return false;
+        }
+      }
+    }
+    return true;
   }
 
   private mapCapabilitiesToStateProperties(

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -236,8 +236,11 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(state.getBrightness()?.level).toBe(75);
     });
 
-    it('should handle device offline state', async () => {
-      const offlineStateResponse = {
+    it('defaults online=true when the online capability is absent from the response', async () => {
+      // Some device models respond to /device/state without including the
+      // online capability at all. Preserve historical behavior by assuming
+      // online in that case — we got a response, after all.
+      const responseWithoutOnline = {
         ...mockStateResponse,
         data: {
           ...mockStateResponse.data,
@@ -250,17 +253,108 @@ describe('GoveeDeviceRepository Integration Tests', () => {
           ],
         },
       };
-
       server.use(
-        http.post(`${BASE_URL}/router/api/v1/device/state`, () => {
-          return HttpResponse.json(offlineStateResponse);
-        })
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+          HttpResponse.json(responseWithoutOnline)
+        )
       );
 
       const state = await repository.findState('device123', 'H6159');
-
-      expect(state.online).toBe(true); // API assumes online if response received
+      expect(state.online).toBe(true);
       expect(state.getPowerState()).toBe('off');
+    });
+
+    it('reports online=false when the online capability state says so', async () => {
+      const offlineResponse = {
+        ...mockStateResponse,
+        data: {
+          ...mockStateResponse.data,
+          capabilities: [
+            {
+              type: 'devices.capabilities.online',
+              instance: 'online',
+              state: { value: false },
+            },
+            {
+              type: 'devices.capabilities.on_off',
+              instance: 'powerSwitch',
+              state: { value: false },
+            },
+          ],
+        },
+      };
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+          HttpResponse.json(offlineResponse)
+        )
+      );
+
+      const state = await repository.findState('device123', 'H6159');
+      expect(state.online).toBe(false);
+      expect(state.getPowerState()).toBe('off');
+    });
+
+    it('reports online=true when the online capability state says so', async () => {
+      const onlineResponse = {
+        ...mockStateResponse,
+        data: {
+          ...mockStateResponse.data,
+          capabilities: [
+            {
+              type: 'devices.capabilities.online',
+              instance: 'online',
+              state: { value: true },
+            },
+            {
+              type: 'devices.capabilities.on_off',
+              instance: 'powerSwitch',
+              state: { value: true },
+            },
+          ],
+        },
+      };
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+          HttpResponse.json(onlineResponse)
+        )
+      );
+
+      const state = await repository.findState('device123', 'H6159');
+      expect(state.online).toBe(true);
+      expect(state.getPowerState()).toBe('on');
+    });
+
+    it('tolerates non-boolean online state values (number / string)', async () => {
+      const cases: Array<{ value: unknown; expected: boolean }> = [
+        { value: 1, expected: true },
+        { value: 0, expected: false },
+        { value: 'online', expected: true },
+        { value: 'offline', expected: false },
+        { value: 'TRUE', expected: true },
+      ];
+
+      for (const { value, expected } of cases) {
+        server.use(
+          http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+            HttpResponse.json({
+              ...mockStateResponse,
+              data: {
+                ...mockStateResponse.data,
+                capabilities: [
+                  {
+                    type: 'devices.capabilities.online',
+                    instance: 'online',
+                    state: { value },
+                  },
+                ],
+              },
+            })
+          )
+        );
+
+        const state = await repository.findState('device123', 'H6159');
+        expect(state.online, `value ${JSON.stringify(value)}`).toBe(expected);
+      }
     });
 
     it('should validate device parameters', async () => {


### PR DESCRIPTION
Adds accurate offline detection via \`devices.capabilities.online\` and rolls up the 3.3.0 release (this change + #25's DIY endpoint / snapshot fallback work that is already on main).

## Summary
- \`findState\` now reads \`devices.capabilities.online\` state if present (boolean / numeric 0|1 / string form). Previously hardcoded \`true\` whenever the state endpoint responded, which masked real offline state on devices that report it.
- Defaults to \`true\` when the online capability is absent, preserving behavior for devices that don't emit it.
- Adds 4 integration tests covering online=true, online=false, mixed value types, and absent-capability fallback.
- Bumps package.json + package-lock to 3.3.0, updates CHANGELOG with entries covering both this change and the #25 work already merged.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm test\` — 688 tests pass (up from 685)
- [x] \`npm run build\`

After merge I'll tag \`v3.3.0\` which triggers the release workflow (npm publish + GitHub release).