### PR TITLE
feat: generic toggle/mode state parsing — 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-04-18
+
+### Fixed
+
+- **Generic toggle state parsing**: `DeviceState.getToggle(instance)` now reads any toggle-capability instance — `nightlightToggle`, `gradientToggle`, `sceneStageToggle`, `dreamViewToggle`, and any new instance Govee adds. Previously the state parser hardcoded only the first three, silently dropping `dreamViewToggle` state from responses. Downstream consumers that queried dreamView via the Govee command path could send it but never read back its current state.
+- **Generic mode state parsing**: `DeviceState.getMode(instance)` does the same for mode-capability instances. Was hardcoded to `nightlightScene` and `presetScene` only.
+
+### Added
+
+- `DeviceState.getToggle(instance)` — generic accessor for any toggle instance.
+- `DeviceState.getMode(instance)` — generic accessor for any mode instance.
+
+### Changed
+
+- Existing named accessors (`getNightlightToggle`, `getGradientToggle`, `getSceneStageToggle`, `getNightlightScene`, `getPresetScene`) now delegate to the new generic methods. Behavior is unchanged; they remain on the public API for backwards compatibility.
+
+### Tests
+
+- 3 new integration tests covering `getToggle` with `dreamViewToggle` + unknown-future-instance fallback, `getMode` with mixed numeric/string values, and a regression guard that the named accessors still work on a mixed-capability state response.
+
 ## [3.3.0] - 2026-04-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/domain/entities/DeviceState.ts
+++ b/src/domain/entities/DeviceState.ts
@@ -156,29 +156,45 @@ export class DeviceState {
     return musicState?.value;
   }
 
-  getNightlightToggle(): boolean | undefined {
-    const toggleState = this.getProperty<ToggleState>('nightlightToggle');
+  /**
+   * Generic accessor for any toggle-capability instance (e.g. `nightlightToggle`,
+   * `gradientToggle`, `sceneStageToggle`, `dreamViewToggle`, or any instance
+   * Govee adds in the future). Returns undefined when the device did not
+   * report that instance.
+   */
+  getToggle(instance: string): boolean | undefined {
+    const toggleState = this.getProperty<ToggleState>(instance);
     return toggleState?.value;
+  }
+
+  /**
+   * Generic accessor for any mode-capability instance (e.g. `nightlightScene`,
+   * `presetScene`, or any mode instance Govee adds). Returns undefined when
+   * the device did not report that instance.
+   */
+  getMode(instance: string): string | number | undefined {
+    const modeState = this.getProperty<ModeState>(instance);
+    return modeState?.value;
+  }
+
+  getNightlightToggle(): boolean | undefined {
+    return this.getToggle('nightlightToggle');
   }
 
   getGradientToggle(): boolean | undefined {
-    const toggleState = this.getProperty<ToggleState>('gradientToggle');
-    return toggleState?.value;
+    return this.getToggle('gradientToggle');
   }
 
   getSceneStageToggle(): boolean | undefined {
-    const toggleState = this.getProperty<ToggleState>('sceneStageToggle');
-    return toggleState?.value;
+    return this.getToggle('sceneStageToggle');
   }
 
   getNightlightScene(): string | number | undefined {
-    const modeState = this.getProperty<ModeState>('nightlightScene');
-    return modeState?.value;
+    return this.getMode('nightlightScene');
   }
 
   getPresetScene(): string | number | undefined {
-    const modeState = this.getProperty<ModeState>('presetScene');
-    return modeState?.value;
+    return this.getMode('presetScene');
   }
 
   isPoweredOn(): boolean {

--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -958,24 +958,21 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
           value: new MusicMode(modeValue.modeId, modeValue.sensitivity),
         };
       } else if (capability.type.includes('toggle')) {
-        if (capability.instance === 'nightlightToggle') {
-          result.nightlightToggle = {
-            value: capability.state.value === 1 || capability.state.value === true,
-          };
-        } else if (capability.instance === 'gradientToggle') {
-          result.gradientToggle = {
-            value: capability.state.value === 1 || capability.state.value === true,
-          };
-        } else if (capability.instance === 'sceneStageToggle') {
-          result.sceneStageToggle = {
+        // Store every toggle instance by its instance name so newer Govee
+        // toggles (dreamViewToggle, future additions) are readable via
+        // DeviceState.getToggle(instance) without a client-side patch.
+        if (typeof capability.instance === 'string' && capability.instance.length > 0) {
+          result[capability.instance] = {
             value: capability.state.value === 1 || capability.state.value === true,
           };
         }
       } else if (capability.type.includes('mode')) {
-        if (capability.instance === 'nightlightScene') {
-          result.nightlightScene = { value: capability.state.value as string | number };
-        } else if (capability.instance === 'presetScene') {
-          result.presetScene = { value: capability.state.value as string | number };
+        // Same generic store for mode instances. Named accessors like
+        // getNightlightScene / getPresetScene remain as thin shims.
+        if (typeof capability.instance === 'string' && capability.instance.length > 0) {
+          result[capability.instance] = {
+            value: capability.state.value as string | number,
+          };
         }
       }
     }

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -659,6 +659,124 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(sceneStageEnabled).toBe(false);
     });
 
+    it('reads dreamViewToggle and any future toggle instance via getToggle(instance)', async () => {
+      // The named accessors (getNightlightToggle etc.) only covered three
+      // toggle instances. Govee devices like RGB IC strips expose
+      // dreamViewToggle, and future firmware may add more. This test
+      // asserts we can read any instance generically.
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+          HttpResponse.json({
+            code: 200,
+            message: 'Success',
+            data: {
+              device: 'device123',
+              sku: 'H6159',
+              capabilities: [
+                {
+                  type: 'devices.capabilities.toggle',
+                  instance: 'dreamViewToggle',
+                  state: { value: 1 },
+                },
+                {
+                  type: 'devices.capabilities.toggle',
+                  instance: 'someFutureToggle',
+                  state: { value: false },
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const state = await repository.findState('device123', 'H6159');
+      expect(state.getToggle('dreamViewToggle')).toBe(true);
+      expect(state.getToggle('someFutureToggle')).toBe(false);
+      expect(state.getToggle('notReportedToggle')).toBeUndefined();
+    });
+
+    it('named toggle accessors delegate to getToggle (regression guard)', async () => {
+      // getNightlightToggle / getGradientToggle / getSceneStageToggle were
+      // previously hardcoded in the state parser. After the generic
+      // refactor, they're thin wrappers around getToggle(). Verify the
+      // backwards-compat shims still work on a mixed-capability response.
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+          HttpResponse.json({
+            code: 200,
+            message: 'Success',
+            data: {
+              device: 'device123',
+              sku: 'H6159',
+              capabilities: [
+                {
+                  type: 'devices.capabilities.toggle',
+                  instance: 'nightlightToggle',
+                  state: { value: true },
+                },
+                {
+                  type: 'devices.capabilities.toggle',
+                  instance: 'gradientToggle',
+                  state: { value: 0 },
+                },
+                {
+                  type: 'devices.capabilities.toggle',
+                  instance: 'sceneStageToggle',
+                  state: { value: 1 },
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const state = await repository.findState('device123', 'H6159');
+      expect(state.getNightlightToggle()).toBe(true);
+      expect(state.getGradientToggle()).toBe(false);
+      expect(state.getSceneStageToggle()).toBe(true);
+    });
+
+    it('reads any mode instance generically via getMode(instance)', async () => {
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/state`, () =>
+          HttpResponse.json({
+            code: 200,
+            message: 'Success',
+            data: {
+              device: 'device123',
+              sku: 'H6159',
+              capabilities: [
+                {
+                  type: 'devices.capabilities.mode',
+                  instance: 'nightlightScene',
+                  state: { value: 7 },
+                },
+                {
+                  type: 'devices.capabilities.mode',
+                  instance: 'presetScene',
+                  state: { value: 'sunset' },
+                },
+                {
+                  type: 'devices.capabilities.mode',
+                  instance: 'futureMode',
+                  state: { value: 42 },
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const state = await repository.findState('device123', 'H6159');
+      expect(state.getMode('nightlightScene')).toBe(7);
+      expect(state.getMode('presetScene')).toBe('sunset');
+      expect(state.getMode('futureMode')).toBe(42);
+      expect(state.getMode('notReported')).toBeUndefined();
+      // Named shims still work:
+      expect(state.getNightlightScene()).toBe(7);
+      expect(state.getPresetScene()).toBe('sunset');
+    });
+
     it('should handle state with nightlight scene capability', async () => {
       const nightlightSceneStateResponse = {
         code: 200,


### PR DESCRIPTION
Closes a state-parsing gap surfaced by the plugin-side audit: \`dreamViewToggle\` was commandable but not readable.

## Problem
\`mapCapabilitiesToStateProperties\` hardcoded three toggle instances (\`nightlightToggle\`, \`gradientToggle\`, \`sceneStageToggle\`) and two mode instances (\`nightlightScene\`, \`presetScene\`). Everything else — including \`dreamViewToggle\` on RGB IC strips — was silently dropped. Plugin consumers that wired a Toggle action to DreamView could send on/off commands but the live-state sync always returned \`undefined\`, breaking the button title state indicator.

## Fix
- Refactor the state parser to store every toggle/mode instance generically by its instance name.
- Add \`DeviceState.getToggle(instance)\` and \`getMode(instance)\` as the canonical read-side API.
- Keep the existing named accessors (\`getNightlightToggle\`, \`getGradientToggle\`, \`getSceneStageToggle\`, \`getNightlightScene\`, \`getPresetScene\`) as thin wrappers that delegate to the new helpers — no breaking change.

## Test plan
- [x] \`npm run lint\` / \`format:check\` pass
- [x] \`npm test\` — 691 pass (was 688)
- [x] \`npm run build\`

After merge I'll tag \`v3.3.1\` which publishes to npm + cuts a GitHub release. Plugin PR to consume the new accessor follows immediately after.