### PR TITLE
fix: send numeric id for snapshot control (speculative, pending #198 user confirmation)

### DIFF
--- a/src/domain/entities/Command.ts
+++ b/src/domain/entities/Command.ts
@@ -123,9 +123,12 @@ export class LightSceneCommand extends Command {
 }
 
 /**
- * Activates a user-saved snapshot. Shares the API payload shape with
- * {@link LightSceneCommand} (both live under `dynamic_scene`) but uses
- * `instance: "snapshot"` instead of `"lightScene"`.
+ * Activates a user-saved snapshot. Lives under `devices.capabilities.dynamic_scene`
+ * with `instance: "snapshot"`. The control payload is the numeric snapshot ID —
+ * Govee's API silently accepts `{ id, paramId }` object payloads with a 200 OK
+ * but does not actually apply the snapshot when the value is shaped that way.
+ * This mirrors the DIY scene fix and resolves issue #198 (snapshot button shows
+ * green confirmation but light state never changes).
  */
 export class SnapshotCommand extends Command {
   readonly name = 'snapshot';
@@ -136,15 +139,15 @@ export class SnapshotCommand extends Command {
     this._snapshot = snapshot;
   }
 
-  get value(): { paramId: number; id: number } {
-    return this._snapshot.toApiValue();
+  get value(): number {
+    return this._snapshot.id;
   }
 
   get snapshot(): Snapshot {
     return this._snapshot;
   }
 
-  toObject(): { name: string; value: { paramId: number; id: number } } {
+  toObject(): { name: string; value: number } {
     return { name: this.name, value: this.value };
   }
 }
@@ -416,6 +419,12 @@ export class CommandFactory {
         throw new Error(`Invalid light scene command value: ${obj.value}`);
 
       case 'snapshot':
+        // Accept both shapes when deserializing: numeric ID (current API)
+        // and the historical { id, paramId } object so persisted settings
+        // from older releases continue to load.
+        if (typeof obj.value === 'number') {
+          return new SnapshotCommand(new Snapshot(obj.value, obj.value, 'Snapshot'));
+        }
         if (typeof obj.value === 'object' && obj.value !== null) {
           const snapshotValue = obj.value as { id: number; paramId: number };
           return new SnapshotCommand(

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { GoveeDeviceRepository } from '../../src/infrastructure/GoveeDeviceRepository';
-import { CommandFactory } from '../../src/domain/entities/Command';
+import { CommandFactory, SnapshotCommand } from '../../src/domain/entities/Command';
 import { ColorRgb, ColorTemperature, Brightness } from '../../src/domain/value-objects';
+import { Snapshot } from '../../src/domain/value-objects/Snapshot';
 import { GoveeApiError, InvalidApiKeyError, RateLimitError, NetworkError } from '../../src/errors';
 
 const BASE_URL = 'https://openapi.api.govee.com';
@@ -1362,6 +1363,30 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       await expect(repository.sendCommand('device123', 'H6159', command)).rejects.toThrow(
         GoveeApiError
       );
+    });
+
+    it('sends snapshot control as a bare numeric id, not an object', async () => {
+      // Regression guard for plugin issue #198: Govee's /device/control
+      // returns 200 OK when the snapshot value is { id, paramId } but
+      // silently does not apply the snapshot. The DIY scene fix (PR #25)
+      // already moved DIY to numeric; snapshot follows the same shape.
+      let observedValue: unknown;
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/control`, async ({ request }) => {
+          const body = (await request.json()) as any;
+          expect(body.payload.capability.type).toBe('devices.capabilities.dynamic_scene');
+          expect(body.payload.capability.instance).toBe('snapshot');
+          observedValue = body.payload.capability.value;
+          return HttpResponse.json(mockCommandResponse);
+        })
+      );
+
+      const command = new SnapshotCommand(new Snapshot(54321, 99999, 'Reading'));
+      await expect(
+        repository.sendCommand('device123', 'H6159', command)
+      ).resolves.not.toThrow();
+      expect(observedValue).toBe(54321);
+      expect(typeof observedValue).toBe('number');
     });
   });
 

--- a/tests/unit/entities/Command.test.ts
+++ b/tests/unit/entities/Command.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { 
-  PowerOnCommand, 
-  PowerOffCommand, 
-  BrightnessCommand, 
-  ColorCommand, 
+import {
+  PowerOnCommand,
+  PowerOffCommand,
+  BrightnessCommand,
+  ColorCommand,
   ColorTemperatureCommand,
-  CommandFactory 
+  SnapshotCommand,
+  CommandFactory,
 } from '../../../src/domain/entities/Command';
 import { ColorRgb, ColorTemperature, Brightness } from '../../../src/domain/value-objects';
+import { Snapshot } from '../../../src/domain/value-objects/Snapshot';
 
 describe('Command classes', () => {
   describe('PowerOnCommand', () => {
@@ -284,6 +286,51 @@ describe('CommandFactory', () => {
     it('should throw error for invalid presetScene command value', () => {
       expect(() => CommandFactory.fromObject({ name: 'presetScene', value: { invalid: true } }))
         .toThrow('Invalid mode command value: [object Object]');
+    });
+  });
+
+  describe('SnapshotCommand', () => {
+    // Regression coverage for plugin issue #198: Govee's API returns 200 OK
+    // when a snapshot control command is sent with an object-shaped value
+    // like { id, paramId }, but does not actually apply the snapshot. The
+    // dedicated DIY scene fix (PR #25) already switched DIY commands to a
+    // bare numeric ID. Snapshot control matches that pattern.
+
+    it('serializes value as the numeric snapshot id, not an object', () => {
+      const command = new SnapshotCommand(new Snapshot(12345, 67890, 'Reading'));
+      expect(command.value).toBe(12345);
+      expect(command.value).not.toEqual({ id: 12345, paramId: 67890 });
+    });
+
+    it('toObject returns the numeric value', () => {
+      const command = new SnapshotCommand(new Snapshot(42, 99, 'Movie night'));
+      expect(command.toObject()).toEqual({ name: 'snapshot', value: 42 });
+    });
+
+    it('CommandFactory.fromObject accepts numeric value (current API)', () => {
+      const command = CommandFactory.fromObject({ name: 'snapshot', value: 7777 });
+      expect(command.name).toBe('snapshot');
+      expect(command.value).toBe(7777);
+    });
+
+    it('CommandFactory.fromObject still accepts { id, paramId } (backwards compat)', () => {
+      // Settings persisted by older releases must still deserialize so
+      // users don't lose their configured snapshot steps / buttons.
+      const command = CommandFactory.fromObject({
+        name: 'snapshot',
+        value: { id: 1001, paramId: 2001 },
+      });
+      expect(command.name).toBe('snapshot');
+      // After round-trip the value normalizes to the numeric id used on
+      // the wire; paramId is preserved on the domain object but not
+      // serialized back out.
+      expect(command.value).toBe(1001);
+    });
+
+    it('CommandFactory.fromObject throws on null/invalid snapshot value', () => {
+      expect(() => CommandFactory.fromObject({ name: 'snapshot', value: null })).toThrow(
+        'Invalid snapshot command value: null'
+      );
     });
   });
 });


### PR DESCRIPTION
**Draft / not for merge until reporter confirms.**

Speculative fix for plugin issue [#198](https://github.com/felixgeelhaar/govee-light-management/issues/198). Ready to go when @PnnnG's plugin log confirms the payload shape is indeed the issue.

## Problem
Users see the green confirmation mark on a Snapshot button but the light doesn't change. Govee's API returns 200 OK so the plugin has no way to know the command didn't apply. PR #25 hit the identical pattern with DIY scenes: Govee silently accepts \`{ id, paramId }\` object payloads for \`dynamic_scene\` instances but only applies the scene when the value is a bare numeric ID.

Both \`diyScene\` and \`snapshot\` live under \`devices.capabilities.dynamic_scene\`, so the fix pattern should be identical.

## Change
- \`SnapshotCommand.value\` returns a bare number (was \`{ id, paramId }\`)
- \`SnapshotCommand.toObject\` serializes \`{ name, value: number }\`
- \`CommandFactory.fromObject\` still accepts both shapes when deserializing so older persisted settings continue to load

## Tests
- Unit: \`SnapshotCommand\` serializes as numeric; \`fromObject\` accepts numeric and legacy \`{ id, paramId }\`; invalid null throws
- Integration: \`/device/control\` receives a numeric value for the snapshot capability, not an object — regression guard for the exact shape the Govee API expects

## Why draft
Changing the payload shape blindly carries risk of regressing users whose snapshots currently work on devices that still expect the object shape. Waiting for @PnnnG's plugin log to confirm the current shape was indeed silently rejected, then we'll:
1. Un-draft and merge
2. Tag v3.3.2 (client)
3. Bump plugin dep and cut v2.4.1 (plugin)

If instead the log shows a 4xx error or the device doesn't support snapshot control, we take a different path (plugin-side capability check) and this PR stays closed unmerged.