### PR TITLE
chore: release v3.3.2 — snapshot payload fix bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-04-20
+
+### Fixed
+
+- **Snapshot control payload shape**: `SnapshotCommand.value` is now a bare numeric ID matching the DIY scene fix from 3.3.0. Govee's cloud API silently accepts the historical `{ id, paramId }` object payload with a 200 OK response but does not actually apply the snapshot — the dedicated Govee mobile app sends the numeric ID, and so must this client. Reported in plugin issue [#198](https://github.com/felixgeelhaar/govee-light-management/issues/198) where users saw the green confirmation mark but the light never changed state.
+- **Backwards-compatible deserialization**: `CommandFactory.fromObject` still accepts the legacy `{ id, paramId }` object shape when loading persisted snapshot commands from older settings, so existing Stream Deck buttons continue to work after the upgrade.
+
+### Tests
+
+- 6 new tests covering numeric serialization, legacy object deserialization, and an integration-level regression guard that the outgoing `/device/control` payload is a number (not an object).
+
 ## [3.3.1] - 2026-04-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump + CHANGELOG for v3.3.2. The fix itself merged in #29 once PnnnG confirmed H60B0 snapshot activation works from the Govee mobile app (so the device supports the API — only the payload shape was wrong).