### PR TITLE
fix: route dreamViewToggle + future toggle/mode instances to correct capability type (v3.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.3] - 2026-04-20
+
+### Fixed
+
+- **`dreamViewToggle` and future toggle/mode instances now route to the correct capability type.** `convertCommandToCapability` previously fell back to `devices.capabilities.${commandName}` for any command name not in its explicit map, producing nonsense types like `devices.capabilities.dreamViewToggle`. Govee either rejected or silently accepted these requests — the DreamView toggle command was being sent but never applied. Fixed both defensively (added `dreamViewToggle` to the explicit map) and future-proof (suffix-based fallback: any `*Toggle` maps to `devices.capabilities.toggle`, any `*Scene` to `devices.capabilities.mode`). New toggle / mode instances Govee introduces will now route correctly without a client patch.
+
+### Tests
+
+- 3 new integration tests covering the dreamViewToggle route, a hypothetical future `*Toggle` instance via the suffix fallback, and a hypothetical future `*Scene` mode instance.
+
 ## [3.3.2] - 2026-04-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "MIT",
       "dependencies": {
         "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -772,7 +772,10 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
   } {
     const cmdObj = command.toObject();
 
-    // Map command names to capability types
+    // Map command names to capability types. The explicit entries cover
+    // all known Govee-defined instances; the suffix fallback below
+    // catches future additions so a new toggle / mode instance doesn't
+    // require a client patch before it can be sent.
     const capabilityTypeMap: Record<string, string> = {
       turn: 'devices.capabilities.on_off',
       brightness: 'devices.capabilities.range',
@@ -786,6 +789,7 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
       musicMode: 'devices.capabilities.music_setting',
       nightlightToggle: 'devices.capabilities.toggle',
       gradientToggle: 'devices.capabilities.toggle',
+      dreamViewToggle: 'devices.capabilities.toggle',
       sceneStageToggle: 'devices.capabilities.toggle',
       nightlightScene: 'devices.capabilities.mode',
       presetScene: 'devices.capabilities.mode',
@@ -838,10 +842,24 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
     }
 
     return {
-      type: capabilityTypeMap[cmdObj.name] || `devices.capabilities.${cmdObj.name}`,
+      type: capabilityTypeMap[cmdObj.name] ?? this.inferCapabilityType(cmdObj.name),
       instance,
       value,
     };
+  }
+
+  /**
+   * Best-effort capability-type inference when the command name is not
+   * in the explicit map. Catches future Govee toggle / mode instances
+   * so a new instance name (e.g. `musicSyncToggle`) doesn't require a
+   * client patch to route correctly. Falls back to the legacy
+   * `devices.capabilities.${name}` pattern for truly unknown commands;
+   * the server will reject those with a clear error message.
+   */
+  private inferCapabilityType(commandName: string): string {
+    if (commandName.endsWith('Toggle')) return 'devices.capabilities.toggle';
+    if (commandName.endsWith('Scene')) return 'devices.capabilities.mode';
+    return `devices.capabilities.${commandName}`;
   }
 
   private packColorRgbValue(value: unknown): unknown {

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -1388,6 +1388,69 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(observedValue).toBe(54321);
       expect(typeof observedValue).toBe('number');
     });
+
+    it('routes dreamViewToggle to devices.capabilities.toggle (not devices.capabilities.dreamViewToggle)', async () => {
+      // Pre-fix the convertCommandToCapability fallback produced
+      // `devices.capabilities.dreamViewToggle`, which Govee either
+      // rejected or silently ignored. dreamViewToggle lives under the
+      // generic toggle capability with the instance name as the
+      // discriminator.
+      let observedType: unknown;
+      let observedInstance: unknown;
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/control`, async ({ request }) => {
+          const body = (await request.json()) as any;
+          observedType = body.payload.capability.type;
+          observedInstance = body.payload.capability.instance;
+          return HttpResponse.json(mockCommandResponse);
+        })
+      );
+
+      const command = CommandFactory.toggle('dreamViewToggle', true);
+      await expect(
+        repository.sendCommand('device123', 'H6159', command)
+      ).resolves.not.toThrow();
+      expect(observedType).toBe('devices.capabilities.toggle');
+      expect(observedInstance).toBe('dreamViewToggle');
+    });
+
+    it('routes a future unknown *Toggle instance to devices.capabilities.toggle (suffix fallback)', async () => {
+      // Govee adds new toggle instances over time (nightlight, gradient,
+      // dreamView, sceneStage have all appeared in different firmware
+      // cycles). A new instance like `musicSyncToggle` should route
+      // correctly without a client patch.
+      let observedType: unknown;
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/control`, async ({ request }) => {
+          const body = (await request.json()) as any;
+          observedType = body.payload.capability.type;
+          return HttpResponse.json(mockCommandResponse);
+        })
+      );
+
+      const command = CommandFactory.toggle('musicSyncToggle', false);
+      await expect(
+        repository.sendCommand('device123', 'H6159', command)
+      ).resolves.not.toThrow();
+      expect(observedType).toBe('devices.capabilities.toggle');
+    });
+
+    it('routes a future unknown *Scene mode instance to devices.capabilities.mode', async () => {
+      let observedType: unknown;
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/control`, async ({ request }) => {
+          const body = (await request.json()) as any;
+          observedType = body.payload.capability.type;
+          return HttpResponse.json(mockCommandResponse);
+        })
+      );
+
+      const command = CommandFactory.mode('futureScene', 42);
+      await expect(
+        repository.sendCommand('device123', 'H6159', command)
+      ).resolves.not.toThrow();
+      expect(observedType).toBe('devices.capabilities.mode');
+    });
   });
 
   describe('request headers and authentication', () => {


### PR DESCRIPTION
Closes the follow-up noted during the v3.3.1 PR #28: `convertCommandToCapability`'s fallback produced `devices.capabilities.dreamViewToggle` (not a real capability type) for any command name not in its explicit map.

## Fix
Two-part:
1. **Explicit map entry** for `dreamViewToggle` — closes the immediate bug.
2. **Suffix fallback** `inferCapabilityType`: any `*Toggle` routes to `devices.capabilities.toggle`, any `*Scene` to `devices.capabilities.mode`. Future Govee toggle / mode instances route correctly without a client patch.

Same Open/Closed principle as 3.3.1's generic `getToggle` on the read side.

## Tests
- [x] 3 new integration tests: dreamViewToggle route, future `*Toggle` via fallback, future `*Scene` via fallback.
- [x] Total 697 → 700 (+3)
- [x] lint / format / build pass

Once merged I'll tag v3.3.3 and ship a plugin consumer update.