### PR TITLE
fix(scenes): resilient parsing so one odd entry doesn't hide all scenes

### DIFF
--- a/src/infrastructure/response-schemas.ts
+++ b/src/infrastructure/response-schemas.ts
@@ -170,17 +170,25 @@ export const GoveeAnySceneOptionSchema = z.object({
   value: z.unknown(),
 });
 
+// DIY scene values come in several shapes across device models (bare
+// numeric ID, structured { id, paramId }, and occasional opaque handles).
+// Accept any value here and let parseStructuredDynamicSceneValue decide
+// per-option, so one unrecognized entry never invalidates the whole list.
 export const GoveeDiySceneOptionSchema = z.object({
   name: z.string(),
-  value: z.union([z.number(), GoveeStructuredSceneValueSchema]),
+  value: z.unknown(),
 });
 
-// Dynamic Scenes capability schema
+// Dynamic Scenes capability schema.
+//
+// dataType is optional: some models (e.g. Curtain Lights H70B6) omit it on
+// the scene capability. Requiring it would reject the entire response and
+// surface as an empty scene dropdown — see govee-light-management #250.
 export const GoveeDynamicSceneCapabilitySchema = z.object({
   type: z.string(),
   instance: z.string(),
   parameters: z.object({
-    dataType: z.string(),
+    dataType: z.string().optional(),
     options: z.array(GoveeAnySceneOptionSchema),
   }),
 });
@@ -189,7 +197,7 @@ export const GoveeDiySceneCapabilitySchema = z.object({
   type: z.string(),
   instance: z.string(),
   parameters: z.object({
-    dataType: z.string(),
+    dataType: z.string().optional(),
     options: z.array(GoveeDiySceneOptionSchema),
   }),
 });

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -1265,6 +1265,39 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(scenes[1].id).toBe(9001);
       expect(scenes[1].paramId).toBe(9001);
     });
+
+    it('returns scenes even when parameters.dataType is absent', async () => {
+      // Some device models (e.g. Curtain Lights) omit the dataType field on
+      // the scene capability. A required-dataType schema would reject the
+      // whole response and the user would see an empty scene dropdown.
+      const mockResponse = {
+        code: 200,
+        msg: 'success',
+        payload: {
+          sku: 'H70B6',
+          device: 'device123',
+          capabilities: [
+            {
+              type: 'devices.capabilities.dynamic_scene',
+              instance: 'lightScene',
+              parameters: {
+                options: [
+                  { name: 'Floating Mist', value: { id: 5001, paramId: 6001 } },
+                  { name: 'Spectrum', value: { id: 5002, paramId: 6002 } },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/scenes`, () =>
+          HttpResponse.json(mockResponse)
+        )
+      );
+      const scenes = await repository.findDynamicScenes('device123', 'H70B6');
+      expect(scenes.map(s => s.name)).toEqual(['Floating Mist', 'Spectrum']);
+    });
   });
 
   describe('findDiyScenes', () => {
@@ -1350,6 +1383,40 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(scenes[0].paramId).toBe(42);
       expect(scenes[1].id).toBe(100);
       expect(scenes[1].paramId).toBe(200);
+    });
+
+    it('skips DIY entries with an unexpected value shape instead of dropping all', async () => {
+      // A single option whose value is neither a number nor { id, paramId }
+      // (string, null, nested object) must not invalidate the entire DIY
+      // list — the valid scenes still need to reach the dropdown.
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/diy-scenes`, () =>
+          HttpResponse.json({
+            code: 200,
+            msg: 'success',
+            payload: {
+              sku: 'H6159',
+              device: 'device123',
+              capabilities: [
+                {
+                  type: 'devices.capabilities.dynamic_scene',
+                  instance: 'diyScene',
+                  parameters: {
+                    options: [
+                      { name: 'Good One', value: 12001 },
+                      { name: 'Weird Shape', value: 'scene://opaque-handle' },
+                      { name: 'Good Two', value: { id: 12003, paramId: 22003 } },
+                    ],
+                  },
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const scenes = await repository.findDiyScenes('device123', 'H6159');
+      expect(scenes.map(s => s.name)).toEqual(['Good One', 'Good Two']);
     });
 
     it('also recognizes diy_color_setting capability type', async () => {


### PR DESCRIPTION
Scene + DIY response validation was all-or-nothing:
- `parameters.dataType` was **required** — models that omit it (Curtain Lights H70B6) failed the whole parse.
- DIY option `value` was a strict `number | {id,paramId}` union — any unmodeled value shape failed the whole parse.

Either case throws a `ValidationError`, which consumers (govee-light-management) turn into an **empty scene dropdown** — the user sees no scenes at all rather than the ones that did parse.

**Fix:** `dataType` optional; DIY `value` accepts `unknown` and delegates per-option filtering to the existing `parseStructuredDynamicSceneValue` (already skips unparseable entries). Valid scenes now survive alongside odd ones.

2 new regression tests (missing dataType; odd DIY value shape). Full suite 713 pass.

Refs felixgeelhaar/govee-light-management#250