### PR TITLE
chore(release): 3.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release: resilient scene parsing (#33). Tagging v3.3.6 after merge triggers npm publish.