### PR TITLE
fix: route indexed socketToggle/Scene instances to the toggle/mode capability (3.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.8] - 2026-06-03
+
+### Fixed
+
+- **Indexed toggle / mode instances were mis-routed to a non-existent capability type, so per-socket control on multi-outlet devices never worked.** `inferCapabilityType` matched the toggle/mode fallback with `commandName.endsWith('Toggle')` / `endsWith('Scene')`. Multi-outlet devices (e.g. the HS5089 Smart Outlet Extender) expose one toggle capability per socket — `socketToggle1`, `socketToggle2`, … — whose trailing digit means the name does **not** end with the literal `Toggle`. The check fell through to `devices.capabilities.socketToggle1`, an invalid capability type that Govee rejected, so individual sockets could not be turned on/off via the API even though the Govee app controls them fine. The two suffix checks are now anchored regexes (`/Toggle\d*$/`, `/Scene\d*$/`) that also match indexed instances; named (`nightlightToggle`) and future un-indexed (`musicSyncToggle`) instances are unchanged.
+
+### Tests
+
+- New integration test under `sendCommand`: a `socketToggle1` command routes to `devices.capabilities.toggle` with instance `socketToggle1` and value `0`, locking in the multi-outlet fix (regression guard alongside the existing `dreamViewToggle` / `musicSyncToggle` routing tests).
+
 ## [3.3.5] - 2026-05-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixgeelhaar/govee-api-client",
-      "version": "3.3.7",
+      "version": "3.3.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felixgeelhaar/govee-api-client",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "description": "Enterprise-grade TypeScript client library for the Govee Developer REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -852,13 +852,17 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
    * Best-effort capability-type inference when the command name is not
    * in the explicit map. Catches future Govee toggle / mode instances
    * so a new instance name (e.g. `musicSyncToggle`) doesn't require a
-   * client patch to route correctly. Falls back to the legacy
+   * client patch to route correctly. The optional trailing digits match
+   * indexed instances on multi-outlet / multi-zone devices, e.g.
+   * `socketToggle1` / `socketToggle2` on the HS5089 Smart Outlet Extender,
+   * which all live under the generic toggle capability with the instance
+   * name as the discriminator. Falls back to the legacy
    * `devices.capabilities.${name}` pattern for truly unknown commands;
    * the server will reject those with a clear error message.
    */
   private inferCapabilityType(commandName: string): string {
-    if (commandName.endsWith('Toggle')) return 'devices.capabilities.toggle';
-    if (commandName.endsWith('Scene')) return 'devices.capabilities.mode';
+    if (/Toggle\d*$/.test(commandName)) return 'devices.capabilities.toggle';
+    if (/Scene\d*$/.test(commandName)) return 'devices.capabilities.mode';
     return `devices.capabilities.${commandName}`;
   }
 

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -1808,6 +1808,35 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(observedType).toBe('devices.capabilities.toggle');
     });
 
+    it('routes an indexed socketToggle instance to devices.capabilities.toggle', async () => {
+      // Multi-outlet devices (e.g. HS5089 Smart Outlet Extender) expose one
+      // toggle capability per socket, named `socketToggle1`, `socketToggle2`,
+      // etc. The trailing digit means the instance does NOT end with the
+      // literal `Toggle`, so the old `endsWith('Toggle')` suffix check missed
+      // it and the command was mis-routed to `devices.capabilities.socketToggle1`
+      // — which Govee rejected, so individual sockets could not be controlled.
+      let observedType: unknown;
+      let observedInstance: unknown;
+      let observedValue: unknown;
+      server.use(
+        http.post(`${BASE_URL}/router/api/v1/device/control`, async ({ request }) => {
+          const body = (await request.json()) as any;
+          observedType = body.payload.capability.type;
+          observedInstance = body.payload.capability.instance;
+          observedValue = body.payload.capability.value;
+          return HttpResponse.json(mockCommandResponse);
+        })
+      );
+
+      const command = CommandFactory.toggle('socketToggle1', false);
+      await expect(
+        repository.sendCommand('device123', 'HS5089', command)
+      ).resolves.not.toThrow();
+      expect(observedType).toBe('devices.capabilities.toggle');
+      expect(observedInstance).toBe('socketToggle1');
+      expect(observedValue).toBe(0);
+    });
+
     it('routes a future unknown *Scene mode instance to devices.capabilities.mode', async () => {
       let observedType: unknown;
       server.use(


### PR DESCRIPTION
## Problem

Per-socket control on multi-outlet devices (HS5089 Smart Outlet Extender) never worked via the API. Surfaced by [govee-light-management#261](https://github.com/felixgeelhaar/govee-light-management/issues/261).

`inferCapabilityType` matched the toggle/mode fallback with `commandName.endsWith('Toggle')` / `endsWith('Scene')`. Multi-outlet devices expose one toggle capability per socket — `socketToggle1`, `socketToggle2`, … — whose trailing digit means the name does **not** end with the literal `Toggle`. The check fell through to `devices.capabilities.socketToggle1`, an invalid capability type that Govee rejected. The sockets work fine in the Govee app, just not through the developer API.

## Fix

Anchor both suffix checks with regexes that also match indexed instances:

```ts
if (/Toggle\d*$/.test(commandName)) return 'devices.capabilities.toggle';
if (/Scene\d*$/.test(commandName)) return 'devices.capabilities.mode';
```

Named (`nightlightToggle`) and future un-indexed (`musicSyncToggle`) instances are unchanged. Generic — covers any numbered toggle/mode instance on any device, not a single SKU special-case.

## Tests

- TDD red→green. New `sendCommand` integration test: `socketToggle1` routes to `devices.capabilities.toggle` / instance `socketToggle1` / value `0`.
- Full suite: 715 passing, lint + build clean.

## Release

Bumps to **3.3.8**. Tag `v3.3.8` after merge to trigger the publish workflow; consumer (govee-light-management) dep bump follows.