### PR TITLE
fix(music-mode): accept mode id 0 for zero-indexed devices

### DIFF
--- a/src/domain/value-objects/MusicMode.ts
+++ b/src/domain/value-objects/MusicMode.ts
@@ -2,6 +2,9 @@
  * MusicMode value object represents a music-reactive lighting mode
  * configuration for Govee devices that support music synchronization.
  *
+ * Mode ids are device-reported and may be zero-indexed: some devices (e.g.
+ * Curtain Lights Pro H70B6) expose mode id 0 (Floating Mist), so 0 is valid.
+ *
  * @example
  * const musicMode = new MusicMode(1, 50); // Mode 1 with 50% sensitivity
  * const modeOnly = new MusicMode(2); // Mode 2 with default sensitivity
@@ -23,8 +26,8 @@ export class MusicMode {
   }
 
   private validateModeId(modeId: number): void {
-    if (!Number.isInteger(modeId) || modeId <= 0) {
-      throw new Error('Mode ID must be a positive integer');
+    if (!Number.isInteger(modeId) || modeId < 0) {
+      throw new Error('Mode ID must be a non-negative integer');
     }
   }
 

--- a/tests/unit/value-objects/MusicMode.test.ts
+++ b/tests/unit/value-objects/MusicMode.test.ts
@@ -17,11 +17,17 @@ describe('MusicMode', () => {
       expect(musicMode.sensitivity).toBeUndefined();
     });
 
-    it('should throw error when modeId is not a positive integer', () => {
-      expect(() => new MusicMode(-1)).toThrow('Mode ID must be a positive integer');
-      expect(() => new MusicMode(0)).toThrow('Mode ID must be a positive integer');
-      expect(() => new MusicMode(1.5)).toThrow('Mode ID must be a positive integer');
-      expect(() => new MusicMode(NaN)).toThrow('Mode ID must be a positive integer');
+    it('should accept zero as a valid mode id (zero-indexed devices)', () => {
+      const musicMode = new MusicMode(0, 50);
+
+      expect(musicMode.modeId).toBe(0);
+      expect(musicMode.toApiValue()).toEqual({ musicMode: 0, sensitivity: 50 });
+    });
+
+    it('should throw error when modeId is not a non-negative integer', () => {
+      expect(() => new MusicMode(-1)).toThrow('Mode ID must be a non-negative integer');
+      expect(() => new MusicMode(1.5)).toThrow('Mode ID must be a non-negative integer');
+      expect(() => new MusicMode(NaN)).toThrow('Mode ID must be a non-negative integer');
     });
 
     it('should throw error when sensitivity is out of range', () => {
@@ -130,11 +136,13 @@ describe('MusicMode', () => {
     });
 
     it('should validate object properties', () => {
-      expect(() => MusicMode.fromObject({ modeId: -1 }))
-        .toThrow('Mode ID must be a positive integer');
+      expect(() => MusicMode.fromObject({ modeId: -1 })).toThrow(
+        'Mode ID must be a non-negative integer'
+      );
 
-      expect(() => MusicMode.fromObject({ modeId: 1, sensitivity: 150 }))
-        .toThrow('Sensitivity must be between 0 and 100');
+      expect(() => MusicMode.fromObject({ modeId: 1, sensitivity: 150 })).toThrow(
+        'Sensitivity must be between 0 and 100'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Govee devices such as the **Curtain Lights Pro (H70B6)** expose a **zero-indexed** music mode list — `Floating Mist` is mode id **0**. `MusicMode` rejected 0 (`modeId <= 0`), so selecting Floating Mist in a consumer threw `Mode ID must be a positive integer` and the command never reached the device. Spectrum (id 1) and higher worked, which is exactly the symptom reported downstream.

## Change
- `validateModeId`: `modeId < 0` instead of `<= 0`; error reworded to `Mode ID must be a non-negative integer`.
- JSDoc notes 0 is valid (H70B6 Floating Mist).
- Regression test: `new MusicMode(0, 50)` is accepted and serializes to `{ musicMode: 0, sensitivity: 50 }`. Updated the two message-string assertions.

## Tests
- `MusicMode.test.ts`: 26 passed
- Full suite: 715 passed, `tsc --noEmit` clean, prettier clean

## Downstream
Root cause for felixgeelhaar/govee-light-management#250 (Floating Mist shows in the dropdown after the 2.7.7 parser fix but does not trigger). Plugin will bump to the released client and ship the fix.