### PR TITLE
fix(discovery): validate devices individually so one bad device can't hide all

### DIFF
--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
+import { z } from 'zod';
 import { Logger } from 'pino';
 import { IGoveeDeviceRepository } from '../domain/repositories/IGoveeDeviceRepository';
 import { GoveeDevice } from '../domain/entities/GoveeDevice';
@@ -29,7 +30,8 @@ import {
   ValidationError,
 } from '../errors';
 import {
-  GoveeDevicesResponseSchema,
+  GoveeDevicesEnvelopeSchema,
+  GoveeDeviceResponseSchema,
   GoveeStateResponseSchema,
   GoveeCommandResponseSchema,
   GoveeDynamicScenesResponseSchema,
@@ -240,8 +242,11 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
     try {
       const response = await this.httpClient.get('/router/api/v1/user/devices');
 
-      // Validate response with Zod
-      const validationResult = GoveeDevicesResponseSchema.safeParse(response.data);
+      // Validate only the response envelope. Each device is validated on its
+      // own below, so a single entry whose nested capabilities fail strict
+      // parsing cannot reject the entire batch (which previously surfaced as
+      // "no devices found" even when most devices were valid).
+      const validationResult = GoveeDevicesEnvelopeSchema.safeParse(response.data);
 
       if (!validationResult.success) {
         this.logger?.error(
@@ -262,7 +267,27 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
         );
       }
 
-      const devices = apiResponse.data
+      // Validate each device individually; skip (with a warning) any whose
+      // nested capabilities fail strict parsing instead of throwing for the
+      // whole response and hiding every other light.
+      const parsedDevices: z.infer<typeof GoveeDeviceResponseSchema>[] = [];
+      for (const raw of apiResponse.data) {
+        const parsed = GoveeDeviceResponseSchema.safeParse(raw);
+        if (!parsed.success) {
+          const id =
+            raw && typeof raw === 'object' && 'device' in raw
+              ? (raw as { device?: unknown }).device
+              : '[unknown]';
+          this.logger?.warn(
+            { device: id, zodError: parsed.error.issues },
+            'Skipping device that failed schema validation'
+          );
+          continue;
+        }
+        parsedDevices.push(parsed.data);
+      }
+
+      const devices = parsedDevices
         .filter(device => {
           if (
             !device.device ||

--- a/src/infrastructure/response-schemas.ts
+++ b/src/infrastructure/response-schemas.ts
@@ -69,6 +69,17 @@ export const GoveeDevicesResponseSchema = z.object({
   data: z.array(GoveeDeviceResponseSchema),
 });
 
+// Lenient envelope for the devices response. Validates only the wrapper
+// (code / message / an array of raw entries) so a single device whose nested
+// capabilities fail strict parsing cannot reject the entire batch. Each entry
+// is then validated individually against GoveeDeviceResponseSchema in
+// GoveeDeviceRepository.findAll, dropping only the malformed ones.
+export const GoveeDevicesEnvelopeSchema = z.object({
+  code: z.number(),
+  message: z.string(),
+  data: z.array(z.unknown()),
+});
+
 // Device state capability schema
 export const GoveeStateCapabilitySchema = z.object({
   type: z.string().min(1, 'State capability type must be a non-empty string'),

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -186,6 +186,85 @@ describe('GoveeDeviceRepository Integration Tests', () => {
 
       await expect(repository.findAll()).rejects.toThrow(NetworkError);
     });
+
+    it('skips a device whose nested capabilities fail strict parsing and returns the rest', async () => {
+      // The first device advertises a range with a non-numeric `min`, which
+      // violates the strict capability schema. Previously this threw for the
+      // whole batch and hid every light; now only the bad device is dropped.
+      const responseWithOneBadDevice = {
+        code: 200,
+        message: 'Success',
+        data: [
+          {
+            device: 'bad-device',
+            sku: 'H6199',
+            deviceName: 'Malformed Light',
+            capabilities: [
+              {
+                type: 'devices.capabilities.range',
+                instance: 'brightness',
+                parameters: {
+                  dataType: 'INTEGER',
+                  range: { min: 'not-a-number', max: 100, precision: 1 },
+                },
+              },
+            ],
+          },
+          {
+            device: 'good-device',
+            sku: 'H6159',
+            deviceName: 'Working Light',
+            capabilities: [
+              { type: 'devices.capabilities.on_off', instance: 'powerSwitch' },
+              { type: 'devices.capabilities.range', instance: 'brightness' },
+            ],
+          },
+        ],
+      };
+
+      server.use(
+        http.get(`${BASE_URL}/router/api/v1/user/devices`, () => {
+          return HttpResponse.json(responseWithOneBadDevice);
+        })
+      );
+
+      const devices = await repository.findAll();
+
+      expect(devices).toHaveLength(1);
+      expect(devices[0].deviceId).toBe('good-device');
+    });
+
+    it('does not throw when every device is malformed — returns an empty list', async () => {
+      const allBad = {
+        code: 200,
+        message: 'Success',
+        data: [
+          {
+            device: 'bad-1',
+            sku: 'H6199',
+            deviceName: 'Bad One',
+            capabilities: [
+              {
+                type: 'devices.capabilities.range',
+                instance: 'brightness',
+                parameters: {
+                  dataType: 'INTEGER',
+                  range: { min: 'x', max: 'y', precision: 'z' },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      server.use(
+        http.get(`${BASE_URL}/router/api/v1/user/devices`, () => {
+          return HttpResponse.json(allBad);
+        })
+      );
+
+      await expect(repository.findAll()).resolves.toEqual([]);
+    });
   });
 
   describe('findState', () => {


### PR DESCRIPTION
## Problem

`findAll` validated the whole `/user/devices` response with a single strict schema (`GoveeDevicesResponseSchema`, `data: z.array(GoveeDeviceResponseSchema)`). If **any one** device's nested capabilities failed strict parsing — a `range` with non-numeric `min/max/precision`, a `parameters` block missing `dataType`, or (in older versions) unexpected `options[].value` — the whole batch threw `ValidationError` and the caller got **zero devices**.

Downstream this is [govee-light-management#304](https://github.com/felixgeelhaar/govee-light-management/issues/304): a user with a valid API key saw "no devices found" because their first device tripped the strict parser. Confirmed from their log:

```
API response validation failed:
  Invalid input at 'data.0.capabilities.1.parameters.fields.1.options[0..2].value'
```

## Fix

Validate the **envelope** strictly (`code` / `message` / `data` array), then validate **each device individually** — skip only the malformed ones (with a warning) instead of failing the whole response.

- New `GoveeDevicesEnvelopeSchema` (lenient wrapper; `data: z.array(z.unknown())`).
- `findAll` per-device `safeParse`; drops invalid entries, keeps the rest.
- Genuine API errors (non-object response, missing `code`, non-200) still throw as before.

## Tests

- One malformed device (non-numeric `range.min`) → the other device is still returned.
- All devices malformed → resolves to `[]`, no throw.
- Full suite: **717 pass**, build + typecheck clean.

## Follow-up

After release, bump `@felixgeelhaar/govee-api-client` in govee-light-management. The plugin's raw-fetch fallback (v2.7.11) can then relax to a pure safety net, since the client itself no longer zeroes the list.

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb