### PR TITLE
chore(discovery): log malformed Govee payloads as structured learning events

### DIFF
--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -139,6 +139,23 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
     return crypto.randomUUID();
   }
 
+  /**
+   * Compact a Zod issue list into `{ path, code, message, received }` entries
+   * for logging. `path` is dot-joined and `received` (present on type
+   * mismatches) records what Govee actually sent, so recurring quirks can be
+   * spotted across devices without dumping full stack-shaped errors.
+   */
+  private summarizeZodIssues(
+    issues: z.ZodIssue[]
+  ): Array<{ path: string; code: string; message: string; received?: unknown }> {
+    return issues.map(issue => ({
+      path: issue.path.join('.'),
+      code: issue.code,
+      message: issue.message,
+      ...('received' in issue ? { received: (issue as { received?: unknown }).received } : {}),
+    }));
+  }
+
   constructor(config: GoveeApiConfig) {
     this.validateConfig(config);
     this.logger = config.logger;
@@ -275,7 +292,12 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
       // (e.g. an odd scene list) never hides an otherwise-controllable light.
       // Only a device with an unusable identity (bad device/sku/name, or
       // capabilities that isn't an array) is skipped entirely.
+      // Track what we drop so the shape of Govee's quirks can be learned from
+      // logs. Every drop/skip emits a stable `event` marker + the raw payload
+      // and the field path that failed, so occurrences can be aggregated
+      // across devices, SKUs, and users.
       const parsedDevices: z.infer<typeof GoveeDeviceResponseSchema>[] = [];
+      let droppedCapabilities = 0;
       for (const raw of apiResponse.data) {
         const shell = GoveeDeviceShellSchema.safeParse(raw);
         if (!shell.success) {
@@ -283,8 +305,19 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
             raw && typeof raw === 'object' && 'device' in raw
               ? (raw as { device?: unknown }).device
               : '[unknown]';
+          const sku =
+            raw && typeof raw === 'object' && 'sku' in raw
+              ? (raw as { sku?: unknown }).sku
+              : undefined;
           this.logger?.warn(
-            { device: id, zodError: shell.error.issues },
+            {
+              event: 'govee.device.skipped',
+              reason: 'device-identity-invalid',
+              device: id,
+              sku,
+              issues: this.summarizeZodIssues(shell.error.issues),
+              rawDevice: raw,
+            },
             'Skipping device that failed schema validation'
           );
           continue;
@@ -295,7 +328,13 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
         // is kept; malformed individual capabilities are dropped below.
         if (!Array.isArray(shell.data.capabilities)) {
           this.logger?.warn(
-            { device: shell.data.device },
+            {
+              event: 'govee.device.skipped',
+              reason: 'capabilities-not-an-array',
+              device: shell.data.device,
+              sku: shell.data.sku,
+              rawCapabilities: shell.data.capabilities,
+            },
             'Filtering out device with invalid capabilities'
           );
           continue;
@@ -314,14 +353,35 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
           ) {
             validCapabilities.push(cap.data);
           } else {
+            droppedCapabilities++;
+            const meta =
+              rawCap && typeof rawCap === 'object'
+                ? (rawCap as { type?: unknown; instance?: unknown })
+                : {};
             this.logger?.warn(
-              { device: shell.data.device, zodError: cap.success ? undefined : cap.error.issues },
+              {
+                event: 'govee.capability.dropped',
+                reason: cap.success ? 'capability-type-empty' : 'capability-schema-invalid',
+                device: shell.data.device,
+                sku: shell.data.sku,
+                capabilityType: meta.type,
+                capabilityInstance: meta.instance,
+                issues: cap.success ? undefined : this.summarizeZodIssues(cap.error.issues),
+                rawCapability: rawCap,
+              },
               'Dropping capability that failed validation (device kept)'
             );
           }
         }
 
         parsedDevices.push({ ...shell.data, capabilities: validCapabilities });
+      }
+
+      if (droppedCapabilities > 0) {
+        this.logger?.info(
+          { event: 'govee.capabilities.dropped.summary', droppedCapabilities },
+          `Dropped ${droppedCapabilities} malformed capabilit${droppedCapabilities === 1 ? 'y' : 'ies'} across the response (devices kept)`
+        );
       }
 
       const devices = parsedDevices

--- a/tests/integration/GoveeDeviceRepository.test.ts
+++ b/tests/integration/GoveeDeviceRepository.test.ts
@@ -273,6 +273,65 @@ describe('GoveeDeviceRepository Integration Tests', () => {
       expect(devices).toHaveLength(1);
       expect(devices[0].deviceId).toBe('good-device');
     });
+
+    it('emits a structured learning event (sku + capability + failing path) when a capability is dropped', async () => {
+      const warn = vi.fn();
+      const logger = {
+        info: vi.fn(),
+        warn,
+        error: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        fatal: vi.fn(),
+      };
+      const repoWithLogger = new GoveeDeviceRepository({
+        apiKey: 'test-api-key',
+        timeout: 5000,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        logger: logger as any,
+      });
+
+      server.use(
+        http.get(`${BASE_URL}/router/api/v1/user/devices`, () => {
+          return HttpResponse.json({
+            code: 200,
+            message: 'Success',
+            data: [
+              {
+                device: 'device-with-bad-cap',
+                sku: 'H6199',
+                deviceName: 'Quirky Light',
+                capabilities: [
+                  { type: 'devices.capabilities.on_off', instance: 'powerSwitch' },
+                  {
+                    type: 'devices.capabilities.range',
+                    instance: 'brightness',
+                    parameters: {
+                      dataType: 'INTEGER',
+                      range: { min: 'nope', max: 100, precision: 1 },
+                    },
+                  },
+                ],
+              },
+            ],
+          });
+        })
+      );
+
+      await repoWithLogger.findAll();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'govee.capability.dropped',
+          sku: 'H6199',
+          capabilityInstance: 'brightness',
+          issues: expect.arrayContaining([
+            expect.objectContaining({ path: expect.stringContaining('range') }),
+          ]),
+        }),
+        expect.any(String)
+      );
+    });
   });
 
   describe('findState', () => {


### PR DESCRIPTION
## Why

We keep hitting Govee devices whose capability metadata doesn't match the documented shape (see #41, #42, and govee-light-management#304). We now tolerate them — but silently. To actually *learn* the quirks (which SKUs, which capabilities, what value Govee sent), the drops need to be observable.

## What

Every drop/skip in `findAll` now emits a structured, greppable event:

- `govee.device.skipped` — `reason`, device id, `sku`, failing field paths, raw entry
- `govee.capability.dropped` — `reason`, `sku`, capability `type`/`instance`, failing paths + **the value Govee actually sent**, raw capability
- `govee.capabilities.dropped.summary` — count per response

New `summarizeZodIssues()` compacts Zod issues into `{ path, code, message, received }` — so a log line says *which field failed and what arrived*, not a wall of error text. Aggregating these across users builds a per-SKU quirk catalog we can feed back into the schema.

No behavior change — same devices returned; only richer logging. 718 tests pass, build + typecheck clean.

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb