### PR TITLE
style: format discovery resilience changes (unblocks release)

### DIFF
--- a/src/infrastructure/GoveeDeviceRepository.ts
+++ b/src/infrastructure/GoveeDeviceRepository.ts
@@ -346,11 +346,7 @@ export class GoveeDeviceRepository implements IGoveeDeviceRepository {
           // A capability is usable only if it parses AND carries a non-empty
           // type — the type drives command derivation. Drop anything else,
           // keeping the device with its remaining valid capabilities.
-          if (
-            cap.success &&
-            typeof cap.data.type === 'string' &&
-            cap.data.type.trim().length > 0
-          ) {
+          if (cap.success && typeof cap.data.type === 'string' && cap.data.type.trim().length > 0) {
             validCapabilities.push(cap.data);
           } else {
             droppedCapabilities++;


### PR DESCRIPTION
Applies Prettier formatting to `GoveeDeviceRepository.ts`. The v3.3.10 release failed at `format:check` because PR CI doesn't run it but the release workflow does. No logic change; 718 tests still pass.

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb