### PR TITLE
chore: activate husky hooks via prepare script (enforce formatting at commit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write \"src/**/*.{ts,js,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,js,json}\"",
     "docs:validate": "echo 'Validating documentation files...' && test -f docs/LLM_API_REFERENCE.md && test -f docs/EXAMPLES.md && test -f docs/TYPE_DEFINITIONS.md && echo 'Documentation validation complete'",
+    "prepare": "husky",
     "prepublishOnly": "npm run build && npm run docs:validate"
   },
   "keywords": [


### PR DESCRIPTION
## Why

husky + lint-staged were configured (`.husky/pre-commit` → `npx lint-staged` → prettier), but there was **no `prepare` script**, so `npm install` never ran `husky` to set `core.hooksPath`. The hooks stayed dormant — commits skipped the prettier/lint-staged run, unformatted code reached `main`, and the **release workflow's `format:check` failed** (v3.3.10; fixed reactively in #44).

Since branch protection here has no required status checks, PR CI's `format:check` doesn't gate merges either — so commit-time enforcement is the reliable fix.

## Fix

Add `"prepare": "husky"`. On `npm install` the hooks install, so pre-commit auto-formats staged files and unformatted code can't be committed. CI `format:check` remains as a backstop.

Verified locally: after `npm run prepare`, `core.hooksPath=.husky/_` and committing runs lint-staged.

https://claude.ai/code/session_01EUQgzWEdnQ4DFZxV4uAFMb